### PR TITLE
Adjusted chan.queue_declare

### DIFF
--- a/hypermap/aggregator/views.py
+++ b/hypermap/aggregator/views.py
@@ -232,7 +232,7 @@ def get_queued_jobs_number():
                            virtual_host=params.virtual_host,
                            insist=False)
     chan = conn.channel()
-    name, jobs, consumers = chan.queue_declare(queue="celery", passive=True)
+    name, jobs, consumers = chan.queue_declare(queue=“hypermap”, passive=False)
     return jobs
 
 


### PR DESCRIPTION
- named the queue from 'celery' to 'hypermap'
- set passive to False

When adding it as a third party app to geonode I was getting the follwoing exception:

AMQPChannelException at /registry/celery_monitor/
(404, u"NOT_FOUND - no queue 'celery' in vhost '/'", (50, 10), 'Channel.queue_declare')

amqplib docs state that passive If set, the server will not create the queue. The client can use this to check whether a queue exists without modifying the server state.

Since the queue had not been created and was set to passive, the exception above was triggered.

Renamed the queue so it was not generalized as 'celery'.