### PR TITLE
support CSW harvesting (#76)

### DIFF
--- a/hypermap/aggregator/enums.py
+++ b/hypermap/aggregator/enums.py
@@ -1,4 +1,5 @@
 SERVICE_TYPES = (
+    ('OGC:CSW', 'Catalogue Service for the Web (CSW)'),
     ('OGC:WMS', 'Web Map Service (WMS)'),
     ('OGC:WMTS', 'Web Map Tile Service (WMTS)'),
     ('OSGeo:TMS', 'Tile Map Service (TMS)'),
@@ -9,6 +10,7 @@ SERVICE_TYPES = (
 )
 
 CSW_RESOURCE_TYPES = {
+    'OGC:CSW': 'http://www.opengis.net/cat/csw/2.0.2',
     'OGC:WMS': 'http://www.opengis.net/wms',
     'OGC:WMTS': 'http://www.opengis.net/wmts/1.0',
     'OSGeo:TMS': 'https://wiki.osgeo.org/wiki/TMS',

--- a/hypermap/aggregator/models.py
+++ b/hypermap/aggregator/models.py
@@ -22,6 +22,7 @@ from lxml import etree
 from shapely.wkt import loads
 from owslib.namespaces import Namespaces
 from owslib.util import nspath_eval
+from owslib.csw import CatalogueServiceWeb
 from owslib.tms import TileMapService
 from owslib.wms import WebMapService
 from owslib.wmts import WebMapTileService
@@ -284,6 +285,11 @@ class Service(Resource):
             keywords = []
             wkt_geometry = None
             srs = '4326'
+            if self.type == 'OGC:CSW':
+                ows = CatalogueServiceWeb(self.url)
+                title = ows.identification.title
+                abstract = ows.identification.abstract
+                keywords = ows.identification.keywords
             if self.type == 'OGC:WMS':
                 ows = WebMapService(self.url)
                 title = ows.identification.title
@@ -719,7 +725,11 @@ class Endpoint(models.Model):
     imported = models.BooleanField(default=False)
     message = models.TextField(blank=True, null=True)
     url = models.URLField(unique=True, max_length=255)
-    endpoint_list = models.ForeignKey(EndpointList)
+    endpoint_list = models.ForeignKey(EndpointList, blank=True, null=True)
+
+    @property
+    def id_string(self):
+        return str(self.id)
 
 
 class TaskError(models.Model):

--- a/hypermap/aggregator/utils.py
+++ b/hypermap/aggregator/utils.py
@@ -7,11 +7,14 @@ import math
 import traceback
 from urlparse import urlparse
 
+from django.conf import settings
+from owslib.csw import CatalogueServiceWeb
 from owslib.wms import WebMapService
 from owslib.tms import TileMapService
 from owslib.wmts import WebMapTileService
 from arcrest import Folder as ArcFolder
 
+from hypermap.aggregator.enums import SERVICE_TYPES
 
 LOGGER = logging.getLogger(__name__)
 
@@ -43,7 +46,7 @@ def create_services_from_endpoint(url):
     """
     Generate service/services from an endpoint.
     WMS, WMTS, TMS endpoints correspond to a single service.
-    ESRI, CWS endpoints corrispond to many services.
+    ESRI, CSW endpoints corrispond to many services.
     """
     num_created = 0
     endpoint = get_sanitized_endpoint(url)
@@ -75,7 +78,67 @@ def create_services_from_endpoint(url):
         abstract = 'Warper at %s' % domain
         detected = True
 
-    # test if it is WMS, TMS, WMTS or Esri
+    # test if it is CSW, WMS, TMS, WMTS or Esri
+    # CSW
+    try:
+        csw = CatalogueServiceWeb(endpoint)
+        service_links = {}
+        detected = True
+
+        typenames = 'csw:Record'
+        outputschema = 'http://www.opengis.net/cat/csw/2.0.2'
+
+        if 'csw_harvest_pagesize' in settings.PYCSW['manager']:
+            pagesize = int(settings.PYCSW['manager']['csw_harvest_pagesize'])
+        else:
+            pagesize = 10
+
+        print 'Harvesting CSW %s' % endpoint
+        # now get all records
+        # get total number of records to loop against
+        try:
+            csw.getrecords2(typenames=typenames, resulttype='hits',
+                            outputschema=outputschema)
+            matches = csw.results['matches']
+        except:  # this is a CSW, but server rejects query
+            raise RuntimeError(csw.response)
+
+        if pagesize > matches:
+            pagesize = matches
+
+        print 'Harvesting %d CSW records' % matches
+
+        # loop over all catalogue records incrementally
+        for r in range(1, matches+1, pagesize):
+            try:
+                csw.getrecords2(typenames=typenames, startposition=r,
+                                maxrecords=pagesize, outputschema=outputschema, esn='full')
+            except Exception as err:  # this is a CSW, but server rejects query
+                raise RuntimeError(csw.response)
+            for k, v in csw.records.items():
+                # try to parse metadata
+                try:
+                    LOGGER.info('Looking for service links')
+                    if v.references:  # not empty
+                        for ref in v.references:
+                            if ref['scheme'] in [st[0] for st in SERVICE_TYPES]:
+                                if ref['url'] not in service_links:
+                                    service_links[ref['url']] = ref['scheme']
+                except Exception as err:  # parsing failed for some reason
+                    LOGGER.warning('Metadata parsing failed %s', err)
+
+        LOGGER.info('Service links found: %s', service_links)
+        for k, v in service_links.items():
+            try:
+                service = create_service_from_endpoint(k, v)
+                if service is not None:
+                    num_created = num_created + 1
+            except Exception as err:
+                raise RuntimeError('HHypermap error: %s' % err)
+
+    except Exception as e:
+        print str(e)
+
     # WMS
     if not detected:
         try:


### PR DESCRIPTION
# Overview

This PR implements CSW harvesting within HHypermap.

# Workflow

## Example Requests:

### HTTP GET
`http://host/search/csw?service=CSW&version=2.0.2&request=Harvest&resourcetype=http://www.opengis.net/cat/csw/2.0.2&source=http://demo.geonode.org/catalogue/csw`

### HTTP POST
```xml
<Harvest xmlns="http://www.opengis.net/cat/csw/2.0.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/cat/csw/2.0.2 http://schemas.opengis.net/csw/2.0.2/CSW-publication.xsd" service="CSW" version="2.0.2">
  <Source>http://demo.geonode.org/catalogue/csw</Source>
  <ResourceType>http://www.opengis.net/cat/csw/2.0.2</ResourceType>
  <ResourceFormat>application/xml</ResourceFormat>
</Harvest>
```

Upon a CSW client issuing a `Harvest` request for a CSW, pycsw will save the CSW as a HHypermap `Endpoint` object and complete the request immediately with a `csw:TransactionResponse`.

The saved `Endpoint` is acted upon asynchronously via the`hypermap.aggregator.tasks.create_services_from_endpoint` task which adds a CSW handler.  This is where the core CSW harvesting happens:

- scan / cycle CSW to process all metadata records to gather distinct, actionable links
- from each metadata record, gather all links which are within the types in `hypermap.aggregator.enums.SERVICE_TYPES`
- foreach distinct actionable link, save as a `Service` object for HHypermap harvesting

# Related Issue / Discussion

#76 

# Backwards Compatibility

This PR modifies `hypermap.aggregator.models.Endpoint.endpoint_list` adding `null=True` and `blank=True`.   The idea being that an Endpoint does **not** require an endpoint list.

# Additional Information

This PR aligns with changes made in pycsw [master](https://github.com/geopython/pycsw/commit/63c44a0680020fe31a33b60ad75c177fed8cb8de) and [2.0](https://github.com/geopython/pycsw/commit/2255a8591637e2175373da08fccfe7c7c8970007) branch requires a pycsw stable releases for operational deployments.

pycsw transaction enablement is required within `settings.PYCSW['server']['manager']`