### PR TITLE
fix ansible config syntax error

### DIFF
--- a/deploy/ansible/env_vars/vagrant.yml
+++ b/deploy/ansible/env_vars/vagrant.yml
@@ -35,7 +35,7 @@ flower_admin_password: password
 
 
 # Application settings.
-site_url = "http://192.168.33.15:8000/"
+site_url: "http://192.168.33.15:8000/"
 django_settings_file: "settings._vagrant"
 django_secret_key: "akr2icmg1n8%z^3fe3c+)5d0(t^cy-2_25rrl35a7@!scna^1#"
 


### PR DESCRIPTION
# Overview

This PR fixes a bug found when starting HHypermap via `vagrant up` (below):

```bash
(HHypermap)tkralidi@maui:~/Dev/HHypermap/HHypermap/deploy$ vagrant provision
==> default: Running provisioner: ansible...
    default: Running ansible-playbook...
PYTHONUNBUFFERED=1 ANSIBLE_FORCE_COLOR=true ANSIBLE_HOST_KEY_CHECKING=false ANSIBLE_SSH_ARGS='-o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -o ControlMaster=auto -o ControlPersist=60s' ansible-playbook --connection=ssh --timeout=30 --limit="default" --inventory-file=/Users/tkralidi/Dev/HHypermap/HHypermap/.vagrant/provisioners/ansible/inventory -v deploy/ansible/vagrant.yml
No config file found; using defaults
[DEPRECATION WARNING]: Instead of sudo/sudo_user, use become/become_user and 
make sure become_method is 'sudo' (default).
This feature will be removed in a 
future release. Deprecation warnings can be disabled by setting 
deprecation_warnings=False in ansible.cfg.
ERROR! Syntax Error while loading YAML.


The error appears to have been in '/Users/tkralidi/Dev/HHypermap/HHypermap/deploy/ansible/env_vars/vagrant.yml': line 39, column 1, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

site_url = "http://192.168.33.15:8000/"
django_settings_file: "settings._vagrant"
^ here

Ansible failed to complete successfully. Any error output should be
visible above. Please fix these errors and try again.
```