### PR TITLE
fix Service.srs model warning

### DIFF
--- a/hypermap/aggregator/models.py
+++ b/hypermap/aggregator/models.py
@@ -241,7 +241,7 @@ class Service(Resource):
     Service represents a remote geowebservice.
     """
 
-    srs = models.ManyToManyField(SpatialReferenceSystem, blank=True, null=True)
+    srs = models.ManyToManyField(SpatialReferenceSystem, blank=True)
 
     @property
     def get_domain(self):


### PR DESCRIPTION
# Overview

This PR fixes a bug found when starting HHypermap via `paver start` (below):

```bash
(HHypermap)tkralidi@www:~/work/foss4g/HHypermap/HHypermap$ paver start
---> pavement.start
python manage.py runserver 0.0.0.0:8000 &
(HHypermap)tkralidi@www:~/work/foss4g/HHypermap/HHypermap$ Performing system checks...

System check identified some issues:

WARNINGS:
aggregator.Service.srs: (fields.W340) null has no effect on ManyToManyField.

System check identified 1 issue (0 silenced).
```