### PR TITLE
Prevent recursion with same endpoint url

### DIFF
--- a/hypermap/aggregator/models.py
+++ b/hypermap/aggregator/models.py
@@ -1294,9 +1294,11 @@ def endpointlist_post_save(instance, *args, **kwargs):
 
 
 def endpoint_post_save(instance, *args, **kwargs):
+    signals.post_save.disconnect(endpoint_post_save, sender=Endpoint)
     if Endpoint.objects.filter(url=instance.url).count() == 0:
         endpoint = Endpoint(url=instance.url)
         endpoint.save()
+        signals.post_save.connect(endpoint_post_save, sender=Endpoint)        
     if not settings.SKIP_CELERY_TASK:
         update_endpoint.delay(instance)
     else:

--- a/hypermap/aggregator/models.py
+++ b/hypermap/aggregator/models.py
@@ -1298,7 +1298,7 @@ def endpoint_post_save(instance, *args, **kwargs):
     if Endpoint.objects.filter(url=instance.url).count() == 0:
         endpoint = Endpoint(url=instance.url)
         endpoint.save()
-        signals.post_save.connect(endpoint_post_save, sender=Endpoint)        
+        signals.post_save.connect(endpoint_post_save, sender=Endpoint)
     if not settings.SKIP_CELERY_TASK:
         update_endpoint.delay(instance)
     else:


### PR DESCRIPTION
Found an issue. When a new endpoint list is added, an infinite loop with the first endpoint url from the file is generated.
http://stackoverflow.com/questions/10840030/django-post-save-preventing-recursion-without-overriding-model-save