### PR TITLE
Minor fixes for local installation of hhypermap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,8 +71,6 @@ hypermap/media
 hypermap/settings/local_settings.py
 development.db
 
-# IDE specific
-/hypermap/settings/_panchicore.py
 # pycharm
 .idea
 

--- a/README.md
+++ b/README.md
@@ -131,10 +131,10 @@ You need to create a settings file named as your username:
 
 ```
 cd HHypermap/hypermap
-touch settings/_yourusername.py
+touch settings/local_settings.py
 ```
 
-In _yourusername.py you need to add at least the first line, and then the settings specific for your environment, such as preferences about Celery and Solr:
+In local_settings.py you need to add at least the first line, and then the settings specific for your environment, such as preferences about Celery and Solr:
 
 ```
 from settings.default import *  # noqa

--- a/hypermap/settings/default.py
+++ b/hypermap/settings/default.py
@@ -257,3 +257,9 @@ PYCSW = {
 # for each service are updated and checked
 DEBUG_SERVICES = str2bool(os.getenv('DEBUG_SERVICES', 'False'))
 DEBUG_LAYERS_NUMBER = int(os.getenv('DEBUG_LAYERS_NUMBER', '10'))
+
+# Enable local settings.
+try:
+    from local_settings import *  # noqa
+except ImportError:
+    pass

--- a/hypermap/settings/default.py
+++ b/hypermap/settings/default.py
@@ -91,7 +91,7 @@ TEMPLATE_CONTEXT_PROCESSORS = (
 
 ROOT_URLCONF = 'hypermap.urls'
 
-WSGI_APPLICATION = 'hypermap.wsgi.application'
+WSGI_APPLICATION = 'wsgi.application'
 
 DATABASES = {
     'default': {


### PR DESCRIPTION
- Enable the user to have a local_settings.py file instead of _username.py. This removes the task to ignore the file in git.
- django settings reads the wsgi file using the correct path in the default settings