### PR TITLE
enable CSW 3.0.0 support

### DIFF
--- a/hypermap/search/views.py
+++ b/hypermap/search/views.py
@@ -48,7 +48,7 @@ def csw_global_dispatch(request):
     env.update({'local.app_root': os.path.dirname(__file__),
                 'REQUEST_URI': request.build_absolute_uri()})
 
-    csw = server.Csw(settings.PYCSW, env, version='2.0.2')
+    csw = server.Csw(settings.PYCSW, env)
 
     content = csw.dispatch_wsgi()
 


### PR DESCRIPTION
Given pycsw now supports CSW 3, enable support by default against the same endpoint  Clients seeking 2.0.2 support must explicitly specify the `version` parameter to  `2.0.2` as part of CSW requests.  Note that tools like OWSLib and MetaSearch currently explicitly support 2.0.2.