### PR TITLE
organize per catalogs url #149

### DIFF
--- a/hypermap/aggregator/models.py
+++ b/hypermap/aggregator/models.py
@@ -461,6 +461,9 @@ class Catalog(models.Model):
             return True
         return False
 
+    def get_absolute_url(self):
+        return reverse('index', args=[self.slug])
+
 
 class Layer(Resource):
     """
@@ -487,8 +490,11 @@ class Layer(Resource):
         """
         endpoint = self.url
         if self.type not in ('Hypermap:WorldMap',):
-            endpoint = '%s/registry/layer/%s/map/wmts/1.0.0/WMTSCapabilities.xml' % (settings.SITE_URL.rstrip('/'),
-                                                                                     self.id)
+            endpoint = '%s/registry/%s/layer/%s/map/wmts/1.0.0/WMTSCapabilities.xml' % (
+                settings.SITE_URL.rstrip('/'),
+                self.catalog.slug,
+                self.id
+            )
         return endpoint
 
     def get_tile_url(self):

--- a/hypermap/aggregator/templates/aggregator/layer_detail.html
+++ b/hypermap/aggregator/templates/aggregator/layer_detail.html
@@ -61,7 +61,11 @@
               {% elif SEARCH_TYPE == 'solr' %}
               <a href="{{SEARCH_URL}}/select?q=layer_id:{{layer.id}}&wt=json&indent=true" target="new">{{SEARCH_URL}}/select?q=layer_id:{{layer.id}}&wt=json&indent=true</a>
               {% endif %}
-              <li>Metadata: <a href="{{SITE_URL}}/search/csw?service=CSW&version=2.0.2&request=GetRecordById&id={{layer.id}}" target="new">{{SITE_URL}}/search/csw?service=CSW&version=2.0.2&request=GetRecordById&id={{layer.id}}</a></li>
+              <li>Metadata:
+                  <a href="{{SITE_URL}}{% url 'csw_global_dispatch_by_catalog' catalog_slug %}?service=CSW&version=2.0.2&request=GetRecordById&id={{layer.id}}" target="new">
+                    {{SITE_URL}}{% url 'csw_global_dispatch_by_catalog' catalog_slug %}?service=CSW&version=2.0.2&request=GetRecordById&id={{layer.id}}
+                  </a>
+              </li>
               </li>
             {% endif %}
           </ul>

--- a/hypermap/aggregator/templates/aggregator/search.html
+++ b/hypermap/aggregator/templates/aggregator/search.html
@@ -15,10 +15,20 @@
 
   <div class="row">
     <div class="col-md-6">
-      Filter by:
-      {% for type in types_list %}
-        &nbsp;<a href="?filter_by={{ type.0 }}">{{ type.1 }} ({{ type.2 }})</a>
-      {% endfor %}
+
+        Catalogs:
+        <a href="{% url 'index' %}">all ({{ services_count }})</a>
+        {% for catalog in catalogs %}
+            <a href="{{ catalog.get_absolute_url }}">{{ catalog.name }} ({{ catalog.service_set.count }})</a>
+        {% endfor %}
+
+        <br>
+        Filter by:
+        {% for type in types_list %}
+            &nbsp;<a href="?filter_by={{ type.0 }}">{{ type.1 }} ({{ type.2 }})</a>
+        {% endfor %}
+
+
     </div>
     <div class="col-md-6">
       <form id='search' action="." method="get">
@@ -62,10 +72,11 @@
           {% for service in services %}
             <tr>
               <td>
-                <strong>{{ service.get_domain }}</strong>
+                <a href="{{ service.catalog.get_absolute_url }}">{{ service.catalog.name }}</a>:<strong>{{ service.get_domain }}</strong>
                 <br /><a href="{{ service.get_absolute_url }}">{{ service.title|truncatechars:40 }}</a>
                 <br /><a href="{{ service.url }}">{{ service.url|truncatechars:40 }}</a>
                 <br />{{ service.get_type_display }}
+{#                  <a href="{{ service.catalog.get_absolute_url }}"><span class="label label-default">{{ service.catalog.name }}</span></a>#}
               </td>
               <td>{{ service.layer_set.all.count }}</td>
               <td>

--- a/hypermap/aggregator/templates/aggregator/service_detail.html
+++ b/hypermap/aggregator/templates/aggregator/service_detail.html
@@ -65,7 +65,11 @@
                     <a href="{{SEARCH_URL}}/select?q=ServiceId:{{service.id}}&wt=json&indent=true" target="new">{{SEARCH_URL}}/select?q=ServiceId:{{service.id}}&wt=json&indent=true</a>
                     {% endif %}
                 </li>
-                <li>Metadata: <a href="{{SITE_URL}}/registry/search/csw?service=CSW&version=2.0.2&request=GetRepositoryItem&id={{service.id}}" target="new">{{SITE_URL}}/registry/search/csw?service=CSW&version=2.0.2&request=GetRepositoryItem&id={{service.id}}</a></li>
+                <li>Metadata:
+                    <a href="{{SITE_URL}}{% url 'csw_global_dispatch_by_catalog' catalog_slug %}?service=CSW&version=2.0.2&request=GetRepositoryItem&id={{service.id}}" target="new">
+                        {{SITE_URL}}{% url 'csw_global_dispatch_by_catalog' catalog_slug %}?service=CSW&version=2.0.2&request=GetRepositoryItem&id={{service.id}}
+                    </a>
+                </li>
               </ul>
             </td>
           </tr>

--- a/hypermap/aggregator/urls.py
+++ b/hypermap/aggregator/urls.py
@@ -8,8 +8,12 @@ from hypermap.aggregator import views
 
 urlpatterns = [
     url(r'^$', views.index, name='index'),
+    url(r'^domains/$', views.domains, name='domains'),
+    url(r'^celery_monitor/$', views.celery_monitor, name='celery_monitor'),
+    url(r'^update_progressbar/(?P<task_id>[^/]*)$', views.update_progressbar, name='update_progressbar'),
+    url(r'^update_jobs_number/$', views.update_jobs_number, name='update_jobs_number'),
+
     url(r'^(?P<catalog_slug>[-\w]+)/$', views.index, name='index'),
-    url(r'^domains', views.domains, name='domains'),
     url(r'^(?P<catalog_slug>[-\w]+)/service/(?P<service_id>\d+)/$', views.service_detail, name='service_detail'),
     url(r'^(?P<catalog_slug>[-\w]+)/service/(?P<service_id>\d+)/checks$',
         views.service_checks,
@@ -21,10 +25,7 @@ urlpatterns = [
         name='layer_mapproxy'),
     url(r'^(?P<catalog_slug>[-\w]+)/layer/(?P<layer_id>\d+)/map/config$',
         views.layer_mapproxy,
-        name='layer_mapproxy_config'),
-    url(r'^celery_monitor/$', views.celery_monitor, name='celery_monitor'),
-    url(r'^update_progressbar/(?P<task_id>[^/]*)$', views.update_progressbar, name='update_progressbar'),
-    url(r'^update_jobs_number/$', views.update_jobs_number, name='update_jobs_number'),
+        name='layer_mapproxy_config')
 ]
 
 # urlpatterns += maploom_urls

--- a/hypermap/search/urls.py
+++ b/hypermap/search/urls.py
@@ -4,9 +4,8 @@ from django.conf.urls import include, patterns, url
 from . import views
 
 urlpatterns = [
-    url(r'^csw/(?P<catalog_slug>[\w-]+)/$', views.csw_global_dispatch_by_catalog,
+    url(r'^(?P<catalog_slug>[\w-]+)/csw/$', views.csw_global_dispatch_by_catalog,
         name='csw_global_dispatch_by_catalog'),
-    url(r'^csw$', views.csw_global_dispatch, name='csw_global_dispatch'),
     url(r'^opensearch$', views.opensearch_dispatch, name='opensearch_dispatch')
 ]
 

--- a/hypermap/search_api/static/swagger/search_api.yaml
+++ b/hypermap/search_api/static/swagger/search_api.yaml
@@ -10,7 +10,6 @@ info:
   description: Happy searching :)
 
 #host: "localhost:8000" If the host is not included, the host serving the documentation is to be used (including the port).
-basePath: /registry/api
 schemes:
   - http
 consumes:
@@ -21,7 +20,7 @@ produces:
 # Describe your paths here
 paths:
   # This is a path endpoint. Change it.
-  /search/{catalog_slug}:
+  /registry/{catalog_slug}/api/:
     # This is a HTTP operation
     get:
       # Describe this verb here. Note: you can use markdown
@@ -176,7 +175,7 @@ paths:
           schema:
             $ref: '#/definitions/ErrorResponse'
 
-  /catalogs:
+  /registry/api/catalogs/:
     # This is a HTTP operation
     get:
       parameters:
@@ -184,7 +183,7 @@ paths:
         # Response code
         200:
           description: An array of catalogs
-  /catalogs/{id}:
+  /registry/api/catalogs/{id}/:
     # This is a HTTP operation
     get:
       parameters:

--- a/hypermap/search_api/tests.py
+++ b/hypermap/search_api/tests.py
@@ -167,6 +167,13 @@ class SearchApiTestCase(TestCase):
 
         self.index(self.solr_records)
 
+    def test_catalogs(self):
+        url = settings.SITE_URL + reverse("catalog-list")
+        res = requests.get(url)
+        self.assertEqual(res.status_code, 200)
+        catalogs = res.json()
+        self.assertEqual(len(catalogs), 1)
+
     def test_all_match_docs(self):
         params = self.default_params
         print "searching on [{}]".format(self.api_url)

--- a/hypermap/search_api/urls.py
+++ b/hypermap/search_api/urls.py
@@ -9,7 +9,7 @@ router.register(r'catalogs', views.CatalogViewSet)
 
 
 urlpatterns = [
-    url(r'^search/(?P<catalog_slug>[-\w]+)/$', views.Search.as_view(), name="search_api"),
-    url(r'^docs/$', TemplateView.as_view(template_name='search_api/swagger/index.html')),
-    url(r'^', include(router.urls)),
+    url(r'^api/', include(router.urls)),
+    url(r'^api/docs/$', TemplateView.as_view(template_name='search_api/swagger/index.html')),
+    url(r'^(?P<catalog_slug>[-\w]+)/api/$', views.Search.as_view(), name="search_api"),
 ]

--- a/hypermap/urls.py
+++ b/hypermap/urls.py
@@ -7,9 +7,10 @@ admin.autodiscover()
 urlpatterns = patterns(
     '',
     url(r'^admin/', include(admin.site.urls)),
+    (r'^registry/', include('hypermap.search_api.urls')),
+    (r'^registry/', include('hypermap.search.urls')),
     (r'^registry/', include('hypermap.aggregator.urls')),
-    (r'^registry/search/', include('hypermap.search.urls')),
-    (r'^registry/api/', include('hypermap.search_api.urls')),
+
 )
 
 urlpatterns += patterns(


### PR DESCRIPTION
`/registry/<catalog_name>/api` also can be swaggered with `/registry/api/docs/` providing the catalog slug in the `catalog_slug` field. Other operations that does not requires catalog in url path can be found here `/registry/api/`

`/registry/<catalog_name>/csw` done, provide specs to implement pycsw per catalog. What about the `opensearch_dispatch` view in `search/urls.py` will work also like csw? for instance: `/registry/<catalog_name>/opensearch`? provide specs then.

`/registry/<catalog_name>/` works.

`/registry/<catalog_name>/layers/map` you meant `/registry/<catalog_name>/layer/<layer_id>/map/` also `...map/config` works.

`/registry/` shows all layers, added label with catalog descriptor.