### PR TITLE
Allow uploading the same endpoint to different catalogs #148

### DIFF
--- a/hypermap/aggregator/migrations/0002_auto_20160813_0222.py
+++ b/hypermap/aggregator/migrations/0002_auto_20160813_0222.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('aggregator', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='endpoint',
+            name='url',
+            field=models.URLField(max_length=255),
+        ),
+        migrations.AlterField(
+            model_name='layer',
+            name='csw_last_updated',
+            field=models.CharField(default=b'2016-08-13T02:22:45Z', max_length=32, null=True, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='service',
+            name='csw_last_updated',
+            field=models.CharField(default=b'2016-08-13T02:22:45Z', max_length=32, null=True, blank=True),
+        ),
+    ]

--- a/hypermap/aggregator/migrations/0003_auto_20160813_0227.py
+++ b/hypermap/aggregator/migrations/0003_auto_20160813_0227.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('aggregator', '0002_auto_20160813_0222'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='layer',
+            name='csw_last_updated',
+            field=models.CharField(default=b'2016-08-13T02:27:30Z', max_length=32, null=True, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='service',
+            name='csw_last_updated',
+            field=models.CharField(default=b'2016-08-13T02:27:30Z', max_length=32, null=True, blank=True),
+        ),
+        migrations.AlterUniqueTogether(
+            name='endpoint',
+            unique_together=set([('url', 'catalog')]),
+        ),
+    ]

--- a/hypermap/aggregator/utils.py
+++ b/hypermap/aggregator/utils.py
@@ -53,11 +53,11 @@ def create_service_from_endpoint(endpoint, service_type, title=None, abstract=No
     Create a service from an endpoint if it does not already exists.
     """
     from models import Service
-    if Service.objects.filter(url=endpoint).count() == 0:
+    if Service.objects.filter(url=endpoint, catalog=catalog).count() == 0:
         # check if endpoint is valid
         request = requests.get(endpoint)
         if request.status_code == 200:
-            print 'Creating a %s service for endpoint %s' % (service_type, endpoint)
+            print 'Creating a %s service for endpoint=%s catalog=%s' % (service_type, endpoint, catalog)
             service = Service(
                         type=service_type, url=endpoint, title=title, abstract=abstract,
                         csw_type='service', catalog=catalog
@@ -67,7 +67,7 @@ def create_service_from_endpoint(endpoint, service_type, title=None, abstract=No
         else:
             print 'This endpoint is invalid, status code is %s' % request.status_code
     else:
-        print 'A service for this endpoint %s already exists' % endpoint
+        print 'A service for this endpoint %s in catalog %s already exists' % (endpoint, catalog)
         return None
 
 


### PR DESCRIPTION
Endpoints, Services and Layers on different catalogs are treated as different objects (instead of  unique key in url, let's do unique key in url + catalog id)