### PR TITLE
test search api with docker container

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -24,3 +24,12 @@ services:
   elasticsearch:
     ports:
       - "9200:9200"
+
+  solr:
+    image: solr
+    ports:
+     - "8983:8983"
+    entrypoint:
+      - docker-entrypoint.sh
+      - solr-precreate
+      - hypermap

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,9 @@ services:
   elasticsearch:
    image: elasticsearch
 
+  solr:
+    image: solr
+
   rabbitmq:
      image: rabbitmq
 

--- a/hypermap/aggregator/management/commands/solr_scheme.py
+++ b/hypermap/aggregator/management/commands/solr_scheme.py
@@ -1,6 +1,5 @@
-import requests
-from django.conf import settings
 from django.core.management.base import BaseCommand
+from hypermap.aggregator.solr import SolrHypermap
 
 
 class Command(BaseCommand):
@@ -16,51 +15,5 @@ class Command(BaseCommand):
         solr6 create_core -c hypermap_test
         """
 
-        # read more here: https://cwiki.apache.org/confluence/display/solr/Schema+API
-        schema_url = '%s/schema' % settings.SEARCH_URL
-        schema_url = "http://localhost:8983/solr/hypermap_test/schema"
-
-        # defining fields: https://cwiki.apache.org/confluence/display/solr/Defining+Fields
-        # stored and indexed are default true.
-        fields = [
-            {"name": "abstract", "type": "string"},
-            {"name": "area", "type": "tdouble"},
-            {"name": "availability", "type": "string"},
-            {"name": "bbox", "type": "location_rpt"},
-            {"name": "domain_name", "type": "string"},
-            {"name": "id", "type": "tlong", "required": True},
-            {"name": "is_public", "type": "boolean"},
-            {"name": "last_status", "type": "boolean"},
-            {"name": "layer_date", "type": "tdate", "docValues": True},
-            {"name": "layer_datetype", "type": "string"},
-            {"name": "layer_id", "type": "tlong"},
-            {"name": "layer_originator", "type": "string"},
-            {"name": "location", "type": "string"},
-            {"name": "max_x", "type": "tdouble"},
-            {"name": "max_y", "type": "tdouble"},
-            {"name": "min_x", "type": "tdouble"},
-            {"name": "min_y", "type": "tdouble"},
-            {"name": "name", "type": "string"},
-            {"name": "recent_reliability", "type": "tdouble"},
-            {"name": "reliability", "type": "tdouble"},
-            {"name": "service_id", "type": "tlong"},
-            {"name": "service_type", "type": "string"},
-            {"name": "srs", "type": "string", "multiValued": True},
-            {"name": "tile_url", "type": "string"},
-            {"name": "title", "type": "string"},
-            {"name": "type", "type": "string"},
-            {"name": "url", "type": "string"},
-        ]
-
-        headers = {
-            "Content-type": "application/json"
-        }
-
-        for field in fields:
-            data = {
-                "add-field": field
-            }
-            print data
-            res = requests.post(schema_url, json=data, headers=headers)
-            print res.text
-            print '*' * 20
+        client = SolrHypermap()
+        client.update_schema()

--- a/hypermap/search_api/tests.py
+++ b/hypermap/search_api/tests.py
@@ -7,45 +7,36 @@ from django.test import TestCase
 
 from hypermap.aggregator.models import Catalog
 from hypermap.search_api import utils
+from hypermap.aggregator.solr import SolrHypermap
+
+
+SEARCH_URL = settings.REGISTRY_SEARCH_URL.split('+')[1]
 
 
 class SearchApiTestCase(TestCase):
-
-    def index(self, data):
-        headers = {"content-type": "application/json"}
-        params = {"commitWithin": 1500}
-        solr_json = json.dumps(data)
-        requests.post(self.url_solr_update, data=solr_json, params=params, headers=headers)
-        # solr seems to have a delay indexing the layers.
-        # before to proceed with the tests wait for 2 secs.
-        # otherwise it will return zero docs in the next test.
-        time.sleep(2)
+    """
+    run me
+    python manage.py test hypermap.search_api --settings=hypermap.settings.test --failfast
+    """
 
     def setUp(self):
-        self.url_solr_clear = '%s/update?commit=true' % settings.SEARCH_URL
-        self.url_solr_update = '%s/update/json/docs' % settings.SEARCH_URL
-        self.url_solr_search = '%s/select' % settings.SEARCH_URL
+        self.solr = SolrHypermap()
+        catalog_test_slug = "hypermap"
+        self.url_solr_update = '{0}/solr/{1}/update/json/docs'.format(
+            SEARCH_URL, catalog_test_slug
+        )
+        self.url_solr_search = '{0}/solr/{1}/select'.format(
+            SEARCH_URL, catalog_test_slug
+        )
         self.api_url = "http://localhost:8000{0}".format(reverse("search_api",
-                                                                 args=["hypermap"]))
-        self.default_params = {
-            "search_engine": "solr",
-            "search_engine_endpoint": self.url_solr_search,
-            "q_time": "[* TO *]",
-            "q_geo": "[-90,-180 TO 90,180]",
-            "d_docs_limit": 0,
-            "d_docs_page": 1,
-            "d_docs_sort": "score"
-        }
+                                                                 args=[catalog_test_slug]))
 
         Catalog.objects.get_or_create(
-            name="hypermap", slug="hypermap"
+            name=catalog_test_slug
         )
 
         # delete solr documents
-        headers = {"content-type": "text/xml"}
-        requests.post(self.url_solr_clear,
-                      data="<delete><query>*:*</query></delete>",
-                      headers=headers)
+        self.solr.clear_solr(catalog=catalog_test_slug)
 
         # add test solr documents
         self.solr_records = [
@@ -75,7 +66,10 @@ class SearchApiTestCase(TestCase):
                 "srs": ["EPSG:3857",
                         "EPSG:900913",
                         "EPSG:4326"],
-                "service_id": 1
+                "layer_username": "xxx",
+                "layer_category": "xxx",
+                "centroid_y": 1,
+                "centroid_x": 1,
             },
             {
                 "abstract": "Downtown-New-Orleans-Map ",
@@ -165,9 +159,36 @@ class SearchApiTestCase(TestCase):
 
         ]
 
-        self.index(self.solr_records)
+        # add the schema
+        self.solr.update_schema(catalog=catalog_test_slug)
+
+        headers = {"content-type": "application/json"}
+        params = {"commitWithin": 1500}
+        solr_json = json.dumps(self.solr_records)
+        post_layers = requests.post(self.url_solr_update, data=solr_json, params=params, headers=headers)
+
+        print '> Requesting layers to Solr'
+        print post_layers.text
+        self.assertFalse('error' in post_layers.json())
+
+        # solr have commitWithin 1500.
+        # before to proceed with the tests wait for 2 secs.
+        # otherwise it will return zero docs in the next test.
+        time.sleep(2)
+        # TODO: deeper tests: index with SolrHypermap.layer_to_solr(aggregator.models.Layer)
+
+        self.default_params = {
+            "search_engine": "solr",
+            "search_engine_endpoint": self.url_solr_search,
+            "q_time": "[* TO *]",
+            "q_geo": "[-90,-180 TO 90,180]",
+            "d_docs_limit": 0,
+            "d_docs_page": 1,
+            "d_docs_sort": "score"
+        }
 
     def test_catalogs(self):
+        print '> testing catalogs'
         url = settings.SITE_URL + reverse("catalog-list")
         res = requests.get(url)
         self.assertEqual(res.status_code, 200)
@@ -175,6 +196,7 @@ class SearchApiTestCase(TestCase):
         self.assertEqual(len(catalogs), 1)
 
     def test_all_match_docs(self):
+        print '> testing match all docs'
         params = self.default_params
         print "searching on [{}]".format(self.api_url)
         results = requests.get(self.api_url, params=params)
@@ -184,6 +206,7 @@ class SearchApiTestCase(TestCase):
         self.assertEqual(results["a.matchDocs"], len(self.solr_records))
 
     def test_q_text(self):
+        print '> testing q text'
         params = self.default_params
         params["q_text"] = "title:1"
         params["d_docs_limit"] = 100
@@ -198,6 +221,7 @@ class SearchApiTestCase(TestCase):
             self.assertEqual(doc["title"], "1")
 
     def test_q_time(self):
+        print '> testing q time (format validations)'
         params = self.default_params
 
         # test validations
@@ -206,6 +230,7 @@ class SearchApiTestCase(TestCase):
         # requires [X TO Y]
         self.assertEqual(400, results.status_code)
 
+        print '> testing q time'
         # test asterisks
         # all times
         params["q_time"] = "[* TO *]"
@@ -252,6 +277,7 @@ class SearchApiTestCase(TestCase):
         self.assertEqual(len(results["a.time"]["counts"]), 3)
 
     def test_q_geo(self):
+        print '> testing q geo'
         params = self.default_params
 
         # top right square
@@ -286,9 +312,11 @@ class SearchApiTestCase(TestCase):
         params["q_geo"] = "[-5,-5 5,5]"
         results = requests.get(self.api_url, params=params)
         # validate the format
+        print '> testing q geo (format validations)'
         self.assertEqual(results.status_code, 400)
 
     def test_utilities(self):
+        print '> testing utilities functions'
         # test_parse_datetime_range
         start, end = utils.parse_datetime_range("[2013-03-01 TO 2014-05-02T23:00:00]")
         self.assertTrue(start.get("is_common_era"))

--- a/hypermap/settings/test.py
+++ b/hypermap/settings/test.py
@@ -12,10 +12,7 @@ DATABASES = {
 }
 
 SOLR_ENABLED = True
-SOLR_URL = 'http://localhost:8983/solr/hypermap_test'
-REGISTRY_SEARCH_URL = "elasticsearch+http://localhost:9200"
-
-SEARCH_URL = SOLR_URL
+REGISTRY_SEARCH_URL = os.getenv('REGISTRY_SEARCH_URL', "elasticsearch+http://localhost:9200")
 
 # BROKER_BACKEND = 'memory'
 # BROKER_URL='memory://'


### PR DESCRIPTION
- added solr in docker compose (it auto creates the hypermap core)
- test covers indexing on that core with a Layer schema (mappings), hitting the search api to make some searches based on basic queries (match all, q text, q time, q geo, some facets and validations).