### PR TITLE
Index layers in batch using the Django cache

### DIFF
--- a/hypermap/aggregator/models.py
+++ b/hypermap/aggregator/models.py
@@ -29,7 +29,7 @@ from owslib.wmts import WebMapTileService
 from arcrest import MapService as ArcMapService, ImageService as ArcImageService
 
 from enums import CSW_RESOURCE_TYPES, SERVICE_TYPES, DATE_TYPES
-from tasks import update_endpoint, update_endpoints, check_service, check_layer, index_layer
+from tasks import update_endpoint, update_endpoints, check_service, check_layer
 from utils import get_esri_extent, get_esri_service_name, format_float, flip_coordinates
 
 from hypermap.dynasty.utils import get_mined_dates
@@ -492,7 +492,6 @@ class Layer(Resource):
                     date.append(pydate)
                     date.append(layerdate.type)
                     dates.append(date)
-        print dates
         return dates
 
     def update_thumbnail(self):
@@ -657,11 +656,6 @@ class Layer(Resource):
         try:
             signals.post_save.disconnect(layer_post_save, sender=Layer)
             self.update_thumbnail()
-            if settings.SEARCH_ENABLED:
-                if not settings.SKIP_CELERY_TASK:
-                    index_layer.delay(self)
-                else:
-                    index_layer(self)
             signals.post_save.connect(layer_post_save, sender=Layer)
 
         except Exception, err:

--- a/hypermap/aggregator/solr.py
+++ b/hypermap/aggregator/solr.py
@@ -3,159 +3,48 @@ import pysolr
 import requests
 import logging
 import json
-import datetime
 
-from urlparse import urlparse
 from django.conf import settings
-from django.utils.html import strip_tags
 
-from hypermap.aggregator.utils import mercator_to_llbbox
-
-
-def get_date(layer):
-    """
-    Returns a date for Solr. A date can be detected or from metadata.
-    It can be a range or a simple date in isoformat.
-    """
-    date = None
-    sign = '+'
-    date_type = 1
-    layer_dates = layer.get_layer_dates()
-    # we index the first date!
-    if layer_dates:
-        sign = layer_dates[0][0]
-        date = layer_dates[0][1]
-        date_type = layer_dates[0][2]
-    if date is None:
-        date = layer.created.date()
-    # layer date > 2300 is invalid for sure
-    # TODO put this logic in date miner
-    if date.year > 2300:
-        date = None
-    if date_type == 0:
-        date_type = "Detected"
-    if date_type == 1:
-        date_type = "From Metadata"
-    return get_solr_date(date, (sign == '-')), date_type
+from hypermap.aggregator.utils import layer2dict
 
 
-def get_solr_date(pydate, is_negative):
-    """
-    Returns a date in a valid Solr format from a string.
-    """
-    # check if date is valid and then set it to solr format YYYY-MM-DDThh:mm:ssZ
-    try:
-        if isinstance(pydate, datetime.datetime):
-            solr_date = '%sZ' % pydate.isoformat()[0:19]
-            if is_negative:
-                print '***** This layer has a negative date'
-                solr_date = '-%s' % solr_date
-            return solr_date
-        else:
-            return None
-    except Exception:
-        return None
+logger = logging.getLogger("hypermap")
 
 
 class SolrHypermap(object):
 
-    def get_domain(self, url):
-        urlParts = urlparse(url)
-        hostname = urlParts.hostname
-        if hostname == "localhost":
-            return "Harvard"  # assumption
-        return hostname
-
-    def layer_to_solr(self, layer):
-        logger = logging.getLogger("hypermap")
-        category = None
-        username = None
+    def layers_to_solr(self, layers):
+        """
+        Sync n layers in Solr.
+        """
+        layers_list = []
+        for layer in layers:
+            layer_dict = layer2dict(layer)
+            layers_list.append(layer_dict)
+        layers_json = json.dumps(layers_list)
         try:
-            bbox = None
-            if not layer.has_valid_bbox():
-                message = 'There are not valid coordinates for layer id: %s' % layer.id
-                logger.error(message)
-            else:
-                bbox = [float(layer.bbox_x0), float(layer.bbox_y0), float(layer.bbox_x1), float(layer.bbox_y1)]
-                for proj in layer.service.srs.values():
-                    if proj['code'] in ('102113', '102100'):
-                        bbox = mercator_to_llbbox(bbox)
-                minX = bbox[0]
-                minY = bbox[1]
-                maxX = bbox[2]
-                maxY = bbox[3]
-                # coords hack needed by solr
-                if (minX < -180):
-                    minX = -180
-                if (maxX > 180):
-                    maxX = 180
-                if (minY < -90):
-                    minY = -90
-                if (maxY > 90):
-                    maxY = 90
-                wkt = "ENVELOPE({:f},{:f},{:f},{:f})".format(minX, maxX, maxY, minY)
-                halfWidth = (maxX - minX) / 2.0
-                halfHeight = (maxY - minY) / 2.0
-                area = (halfWidth * 2) * (halfHeight * 2)
-            domain = self.get_domain(layer.service.url)
-            if hasattr(layer, 'layerwm'):
-                category = layer.layerwm.category
-                username = layer.layerwm.username
-            abstract = layer.abstract
-            if abstract:
-                abstract = strip_tags(layer.abstract)
-            else:
-                abstract = ''
-            if layer.type == "WM":
-                originator = username
-            else:
-                originator = domain
-            # now we add the index
-            solr_record = {
-                            'id': layer.id,
-                            'type': 'Layer',
-                            'layer_id': layer.id,
-                            'name': layer.name,
-                            'title': layer.title,
-                            'layer_originator': originator,
-                            'service_id': layer.service.id,
-                            'service_type': layer.service.type,
-                            'layer_category': category,
-                            'layer_username': username,
-                            'url': layer.url,
-                            'reliability': layer.reliability,
-                            'recent_reliability': layer.recent_reliability,
-                            'last_status': layer.last_status,
-                            'is_public': layer.is_public,
-                            'availability': 'Online',
-                            'location': '{"layerInfoPage": "' + layer.get_absolute_url() + '"}',
-                            'abstract': abstract,
-                            'domain_name': layer.service.get_domain
-                            }
-
-            solr_date, date_type = get_date(layer)
-            if solr_date is not None:
-                solr_record['layer_date'] = solr_date
-                solr_record['layer_datetype'] = date_type
-            if bbox is not None:
-                solr_record['min_x'] = minX
-                solr_record['min_y'] = minY
-                solr_record['max_x'] = maxX
-                solr_record['max_y'] = maxY
-                solr_record['area'] = area
-                solr_record['bbox'] = wkt
-                srs_list = [srs.encode('utf-8') for srs in layer.service.srs.values_list('code', flat=True)]
-                # solr_record['srs'] = ', '.join(srs_list)
-                solr_record['srs'] = srs_list
-            if layer.get_tile_url():
-                solr_record['tile_url'] = layer.get_tile_url()
-
-            # time to send request to solr
             url_solr_update = '%s/update/json/docs' % settings.SEARCH_URL
             headers = {"content-type": "application/json"}
             params = {"commitWithin": 1500}
-            solr_json = json.dumps(solr_record)
-            requests.post(url_solr_update, data=solr_json, params=params,  headers=headers)
+            requests.post(url_solr_update, data=layers_json, params=params,  headers=headers)
+            logger.info("Solr synced for the given layers.")
+            return True, None
+        except Exception:
+            logger.error("Error saving solr records - %s" % sys.exc_info()[1])
+            return False, sys.exc_info()[1]
+
+    def layer_to_solr(self, layer):
+        """
+        Sync a layer in Solr.
+        """
+        layer_dict = layer2dict(layer)
+        layer_json = json.dumps(layer_dict)
+        try:
+            url_solr_update = '%s/update/json/docs' % settings.SEARCH_URL
+            headers = {"content-type": "application/json"}
+            params = {"commitWithin": 1500}
+            requests.post(url_solr_update, data=layer_json, params=params,  headers=headers)
             logger.info("Solr record saved for layer with id: %s" % layer.id)
             return True, None
         except Exception:

--- a/hypermap/aggregator/tasks.py
+++ b/hypermap/aggregator/tasks.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 from django.conf import settings
+from django.core.cache import cache
 
 from celery import shared_task
 
@@ -66,11 +67,19 @@ def check_layer(self, layer):
     print 'Checking layer %s' % layer.name
     success, message = layer.check_available()
     # every time a layer is checked it should be indexed
+    # for now we remove indexing but we do it using a scheduled task unless SKIP_CELERY_TASK
     if success and settings.SEARCH_ENABLED:
-        if not settings.SKIP_CELERY_TASK:
-            index_layer.delay(layer)
-        else:
+        if settings.SKIP_CELERY_TASK:
             index_layer(layer)
+        else:
+            # we cache the layer id
+            print 'Caching layer with id %s for syncing with search engine' % layer.id
+            layers = cache.get('layers')
+            if layers is None:
+                layers = set([layer.id])
+            else:
+                layers.add(layer.id)
+            cache.set('layers', layers)
     if not success:
         from hypermap.aggregator.models import TaskError
         task_error = TaskError(
@@ -79,6 +88,43 @@ def check_layer(self, layer):
             message=message
         )
         task_error.save()
+
+
+@shared_task(bind=True)
+def index_cached_layers(self):
+    """
+    Index all layers in the Django cache (Index all layers who have been checked).
+    """
+    from hypermap.aggregator.models import Layer
+    from hypermap.aggregator.solr import SolrHypermap
+    from hypermap.aggregator.models import TaskError
+    solrobject = SolrHypermap()
+    layers_cache = cache.get('layers')
+    layers_list = list(layers_cache)
+    print 'There are %s layers in cache: %s' % (len(layers_list), layers_list)
+    batch_size = settings.SEARCH_BATCH_SIZE
+    batch_lists = [layers_list[i:i+batch_size] for i in range(0, len(layers_list), batch_size)]
+    for batch_list_ids in batch_lists:
+        layers = Layer.objects.filter(id__in=batch_list_ids)
+        if batch_size > len(layers):
+            batch_size = len(layers)
+        print 'Syncing %s/%s layers to Solr: %s' % (batch_size, len(layers_cache), layers)
+        try:
+            success, message = solrobject.layers_to_solr(layers)
+            if success:
+                # remove layers from cache here
+                layers_cache = layers_cache.difference(set(batch_list_ids))
+                cache.set('layers', layers_cache)
+            else:
+                task_error = TaskError(
+                    task_name=self.name,
+                    args=batch_list_ids,
+                    message=message
+                )
+                task_error.save()
+        except:
+            print 'There was an exception here!'
+            self.retry()
 
 
 @shared_task(name="clear_solr")

--- a/hypermap/aggregator/tasks.py
+++ b/hypermap/aggregator/tasks.py
@@ -124,7 +124,6 @@ def index_cached_layers(self):
                 task_error.save()
         except:
             print 'There was an exception here!'
-            self.retry()
 
 
 @shared_task(name="clear_solr")

--- a/hypermap/aggregator/templates/aggregator/celery_monitor.html
+++ b/hypermap/aggregator/templates/aggregator/celery_monitor.html
@@ -121,8 +121,9 @@ setInterval(function(){
 <form action="." method="post">
   {% csrf_token %}
   <input type="submit" name='check_all' value="Check all services">
-  <input type="submit" name='index_all' value="Reindex all layers in Solr">
-  <input type="submit" name='clear_solr' value="Clear Solr">
+  <input type="submit" name='index_all' value="Reindex all layers">
+  <input type="submit" name='index_cached' value="Index cached layers">
+  <input type="submit" name='clear_solr' value="Clear index">
 </form>
 {% endif %}
 

--- a/hypermap/aggregator/utils.py
+++ b/hypermap/aggregator/utils.py
@@ -5,10 +5,13 @@ import re
 import sys
 import math
 import traceback
+import datetime
 from urlparse import urlparse
-
-from django.conf import settings
 from lxml import etree
+
+from django.utils.html import strip_tags
+from django.conf import settings
+
 from owslib.csw import CatalogueServiceWeb, CswRecord
 from owslib.wms import WebMapService
 from owslib.tms import TileMapService
@@ -372,3 +375,144 @@ def bbox2wktpolygon(bbox):
     maxy = float(bbox[3])
     return 'POLYGON((%.2f %.2f, %.2f %.2f, %.2f %.2f, %.2f %.2f, %.2f %.2f))' \
         % (minx, miny, minx, maxy, maxx, maxy, maxx, miny, minx, miny)
+
+
+def get_solr_date(pydate, is_negative):
+    """
+    Returns a date in a valid Solr format from a string.
+    """
+    # check if date is valid and then set it to solr format YYYY-MM-DDThh:mm:ssZ
+    try:
+        if isinstance(pydate, datetime.datetime):
+            solr_date = '%sZ' % pydate.isoformat()[0:19]
+            if is_negative:
+                print '***** This layer has a negative date'
+                solr_date = '-%s' % solr_date
+            return solr_date
+        else:
+            return None
+    except Exception:
+        return None
+
+
+def get_date(layer):
+    """
+    Returns a custom date representation. A date can be detected or from metadata.
+    It can be a range or a simple date in isoformat.
+    """
+    date = None
+    sign = '+'
+    date_type = 1
+    layer_dates = layer.get_layer_dates()
+    # we index the first date!
+    if layer_dates:
+        sign = layer_dates[0][0]
+        date = layer_dates[0][1]
+        date_type = layer_dates[0][2]
+    if date is None:
+        date = layer.created.date()
+    # layer date > 2300 is invalid for sure
+    # TODO put this logic in date miner
+    if date.year > 2300:
+        date = None
+    if date_type == 0:
+        date_type = "Detected"
+    if date_type == 1:
+        date_type = "From Metadata"
+    return get_solr_date(date, (sign == '-')), date_type
+
+
+def get_domain(url):
+    urlParts = urlparse(url)
+    hostname = urlParts.hostname
+    if hostname == "localhost":
+        return "Harvard"  # assumption
+    return hostname
+
+
+def layer2dict(layer):
+    """
+    Return a json representation for a layer.
+    """
+    logger = logging.getLogger("hypermap")
+    category = None
+    username = None
+    bbox = None
+    if not layer.has_valid_bbox():
+        message = 'There are not valid coordinates for layer id: %s' % layer.id
+        logger.error(message)
+    else:
+        bbox = [float(layer.bbox_x0), float(layer.bbox_y0), float(layer.bbox_x1), float(layer.bbox_y1)]
+        for proj in layer.service.srs.values():
+            if proj['code'] in ('102113', '102100'):
+                bbox = mercator_to_llbbox(bbox)
+        minX = bbox[0]
+        minY = bbox[1]
+        maxX = bbox[2]
+        maxY = bbox[3]
+        # coords hack needed by solr
+        if (minX < -180):
+            minX = -180
+        if (maxX > 180):
+            maxX = 180
+        if (minY < -90):
+            minY = -90
+        if (maxY > 90):
+            maxY = 90
+        wkt = "ENVELOPE({:f},{:f},{:f},{:f})".format(minX, maxX, maxY, minY)
+        halfWidth = (maxX - minX) / 2.0
+        halfHeight = (maxY - minY) / 2.0
+        area = (halfWidth * 2) * (halfHeight * 2)
+    domain = get_domain(layer.service.url)
+    if hasattr(layer, 'layerwm'):
+        category = layer.layerwm.category
+        username = layer.layerwm.username
+    abstract = layer.abstract
+    if abstract:
+        abstract = strip_tags(layer.abstract)
+    else:
+        abstract = ''
+    if layer.type == "WM":
+        originator = username
+    else:
+        originator = domain
+
+    layer_dict = {
+                    'id': layer.id,
+                    'type': 'Layer',
+                    'layer_id': layer.id,
+                    'name': layer.name,
+                    'title': layer.title,
+                    'layer_originator': originator,
+                    'service_id': layer.service.id,
+                    'service_type': layer.service.type,
+                    'layer_category': category,
+                    'layer_username': username,
+                    'url': layer.url,
+                    'reliability': layer.reliability,
+                    'recent_reliability': layer.recent_reliability,
+                    'last_status': layer.last_status,
+                    'is_public': layer.is_public,
+                    'availability': 'Online',
+                    'location': '{"layerInfoPage": "' + layer.get_absolute_url() + '"}',
+                    'abstract': abstract,
+                    'domain_name': layer.service.get_domain
+                    }
+
+    solr_date, date_type = get_date(layer)
+    if solr_date is not None:
+        layer_dict['layer_date'] = solr_date
+        layer_dict['layer_datetype'] = date_type
+    if bbox is not None:
+        layer_dict['min_x'] = minX
+        layer_dict['min_y'] = minY
+        layer_dict['max_x'] = maxX
+        layer_dict['max_y'] = maxY
+        layer_dict['area'] = area
+        layer_dict['bbox'] = wkt
+        srs_list = [srs.encode('utf-8') for srs in layer.service.srs.values_list('code', flat=True)]
+        layer_dict['srs'] = srs_list
+    if layer.get_tile_url():
+        layer_dict['tile_url'] = layer.get_tile_url()
+
+    return layer_dict

--- a/hypermap/aggregator/views.py
+++ b/hypermap/aggregator/views.py
@@ -12,7 +12,7 @@ from django.contrib.auth.decorators import login_required
 
 from models import Service, Layer
 from tasks import (check_all_services, check_service, check_layer, remove_service_checks,
-                   index_service, index_all_layers, index_layer, clear_solr)
+                   index_service, index_all_layers, index_layer, index_cached_layers, clear_solr)
 from enums import SERVICE_TYPES
 
 from hypermap import celeryapp
@@ -201,6 +201,11 @@ def celery_monitor(request):
                 index_all_layers()
             else:
                 index_all_layers.delay()
+        if 'index_cached' in request.POST:
+            if settings.SKIP_CELERY_TASK:
+                index_cached_layers()
+            else:
+                index_cached_layers.delay()
         if 'clear_solr' in request.POST:
             if settings.SKIP_CELERY_TASK:
                 clear_solr()

--- a/hypermap/settings/default.py
+++ b/hypermap/settings/default.py
@@ -48,6 +48,7 @@ ALLOWED_HOSTS = []
 SEARCH_ENABLED = str2bool(os.getenv('SEARCH_ENABLED', 'False'))
 SEARCH_TYPE = 'solr'
 SEARCH_URL = os.getenv('SEARCH_URL', 'http://127.0.0.1:8983/solr/search')
+SEARCH_BATCH_SIZE = os.getenv('SEARCH_BATCH_SIZE', 50)
 
 # Application definition
 
@@ -136,8 +137,8 @@ MAPPROXY_CONFIG = os.path.join(MEDIA_ROOT, 'mapproxy_config')
 CELERYBEAT_SCHEDULER = 'djcelery.schedulers.DatabaseScheduler'
 CELERY_RESULT_BACKEND = 'cache+memcached://127.0.0.1:11211/'
 CELERYD_PREFETCH_MULTIPLIER = 25
-
 CELERY_TIMEZONE = 'UTC'
+
 BROKER_URL = os.getenv('BROKER_URL', 'amqp://hypermap:hypermap@127.0.0.1:5672/hypermap')
 
 LOGGING = {
@@ -257,3 +258,12 @@ PYCSW = {
 # for each service are updated and checked
 DEBUG_SERVICES = str2bool(os.getenv('DEBUG_SERVICES', 'False'))
 DEBUG_LAYERS_NUMBER = int(os.getenv('DEBUG_LAYERS_NUMBER', '20'))
+
+# memcached
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
+        'LOCATION': '127.0.0.1:11211',
+        'TIMEOUT': None,
+    }
+}


### PR DESCRIPTION
This PR does the following:

* for each layer that is being checked, its id is added in the django cache (if it is not there already)
* a new task, index_cached_layers, is introduced. This task index all of the layers in the cache
* the task send a batch job with n layers to the search engine (Solr for now). The number of the layers being sent to each batch is defined in the SEARCH_BATCH_SIZE setting
* after successfully having indexed n layers, the n layers ids are removed from the cache

This should help Solr (and ES) reliability and make things much quicker.