### PR TITLE
django env to use pymemcache lib. es backward compatibility on search…

### DIFF
--- a/django.env
+++ b/django.env
@@ -1,6 +1,6 @@
 DATABASE_URL=postgres://postgres:postgres@postgres:5432/postgres
 BROKER_URL=amqp://guest:guest@rabbitmq:5672/
-CACHE_URL=memcached://memcached:11211/
+CACHE_URL=pymemcached://memcached:11211/
 BASE_URL=django
 ALLOWED_HOSTS=['django',]
 REGISTRY_SEARCH_URL=elasticsearch+http://elasticsearch:9200/

--- a/docker-compose.elasticsearch.yml
+++ b/docker-compose.elasticsearch.yml
@@ -2,7 +2,9 @@ version: '2'
 services:
 
   elasticsearch:
-    image: elasticsearch:1.7
+   image: elasticsearch:1.7
+   # TODO: switch comment to test heatmap support.
+   # image: panchicore/elasticsearch-docker
 
   django:
     links:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
 
   elasticsearch:
    image: elasticsearch:1.7
+   # TODO: switch comment to test heatmap support.
+   # image: panchicore/elasticsearch-docker
 
   rabbitmq:
      image: rabbitmq


### PR DESCRIPTION
- django.env: `'pymemcached://HOST:PORT'` For use with the python-memcached library. https://github.com/ghickman/django-cache-url#supported-caches

- make search api query builder work with es 1, 2 and 5. tests passes for ES v5.0.0-alpha feature/heatmap branch.