### PR TITLE
Processing ImageServer services

### DIFF
--- a/hypermap/aggregator/utils.py
+++ b/hypermap/aggregator/utils.py
@@ -347,6 +347,14 @@ def get_single_service(esri, url, endpoint):
         service_to_process = service_to_process.services
     elif service_type is arcrest.server.MapService:
         service_to_process = [service_to_process]
+    elif service_type is arcrest.server.ImageService:
+        service_to_process = [service_to_process]
+    # Some services have ImageServer and MapServer in its endpoint (AmbiguousService).
+    # We create a list with both services
+    else:
+        service_dict = service_to_process.__dict__
+        service_to_process = {idx: val for idx, val in service_dict.iteritems()
+                              if idx in ['ImageServer', 'MapServer']}.values()
 
     return service_to_process
 
@@ -367,16 +375,15 @@ def process_esri_services(esri_services, catalog):
                 )
                 services_created.append(service)
 
-        # Don't process ImageServer until the following issue has been resolved:
-        # https://github.com/mapproxy/mapproxy/issues/235
-        # if '/ImageServer/' in esri_service.url:
-        #     service = create_service_from_endpoint(
-        #         esri_service.url,
-        #         'ESRI:ArcGIS:ImageServer',
-        #         '',
-        #         esri_service.serviceDescription
-        #     )
-        #      services_created.append(service)
+        if '/ImageServer/' in esri_service.url:
+            service = create_service_from_endpoint(
+                esri_service.url,
+                'ESRI:ArcGIS:ImageServer',
+                '',
+                esri_service.serviceDescription,
+                catalog=catalog
+            )
+            services_created.append(service)
 
     return services_created
 


### PR DESCRIPTION
Tests were performed using these urls:
http://www.carsonproperty.info/ArcGIS/rest/services/2014_Aerials/ImageServer/?f=json
http://services.kgs.ku.edu/arcgis/rest/services/IMAGERY_LOCAL/Kingman_County_2005/ImageServer/?f=json
https://gis.ngdc.noaa.gov/arcgis/rest/services/DEM_global_mosaic/ImageServer/?f=json
http://www3.multco.us/ArcGIS/rest/services/Imagery/Urban_2015/ImageServer/?f=json
http://encdirect.noaa.gov/arcgis/rest/services/RNC/NOAA_RNC/ImageServer/?f=json

Visualization in maploom
![image](https://cloud.githubusercontent.com/assets/3285923/18597353/3c869184-7c13-11e6-92db-556ccd40ff93.png)
