### PR TITLE
Upgrade to Elasticsearch v6.0.0-alpha1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ before_install:
   - chmod +x docker-compose
   - sudo mv docker-compose /usr/local/bin
   - sudo apt-get install -y python-flake8
+  - sudo sysctl -w vm.max_map_count=262144
 
 install:
   - make build

--- a/docker-compose.elasticsearch.yml
+++ b/docker-compose.elasticsearch.yml
@@ -2,9 +2,7 @@ version: '2'
 services:
 
   elasticsearch:
-   image: elasticsearch:1.7
-   # TODO: switch comment to test heatmap support.
-   # image: panchicore/elasticsearch-docker
+   image: terranodo/elasticsearch
 
   django:
     links:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,9 +5,7 @@ services:
     image: terranodo/postgis
 
   elasticsearch:
-   image: elasticsearch:1.7
-   # TODO: switch comment to test heatmap support.
-   # image: panchicore/elasticsearch-docker
+   image: terranodo/elasticsearch
 
   rabbitmq:
      image: rabbitmq

--- a/hypermap/tests/test_csw_transactions.py
+++ b/hypermap/tests/test_csw_transactions.py
@@ -12,9 +12,6 @@ from hypermap.aggregator.models import Catalog, Layer, Service
 from hypermap.aggregator.solr import SolrHypermap
 from hypermap.aggregator.tasks import index_cached_layers
 
-BROWSER_HYPERMAP_URL = os.environ.get("BROWSER_HYPERMAP_URL",
-                                      "http://localhost")
-BROWSER_SEARCH_URL = "{0}/_elastic".format(BROWSER_HYPERMAP_URL)
 SEARCH_TYPE = settings.REGISTRY_SEARCH_URL.split('+')[0]
 SEARCH_URL = settings.REGISTRY_SEARCH_URL.split('+')[1]
 SEARCH_TYPE_SOLR = 'solr'

--- a/hypermap/tests/test_end_to_end_selenium_firefox.py
+++ b/hypermap/tests/test_end_to_end_selenium_firefox.py
@@ -17,6 +17,9 @@ SELENIUM_HUB_URL = os.environ.get("SELENIUM_HUB_URL", None)
 BROWSER_HYPERMAP_URL = os.environ.get("BROWSER_HYPERMAP_URL",
                                       "http://localhost")
 BROWSER_SEARCH_URL = "{0}/_elastic".format(BROWSER_HYPERMAP_URL)
+# TODO: Uncomment this when a fix for ES 6.0 with nginx is found.
+#BROWSER_SEARCH_URL = "{0}/_elastic".format(BROWSER_HYPERMAP_URL)
+BROWSER_SEARCH_URL = "http://elasticsearch:9200"
 BROWSER_MAPLOOM_URL = "{0}/_maploom/".format(BROWSER_HYPERMAP_URL)
 WAIT_FOR_CELERY_JOB_PERIOD = int(
     os.environ.get("WAIT_FOR_CELERY_JOB_PERIOD", 30))


### PR DESCRIPTION
This commit upgrades elasticsearch docker to version 6.0.0-alpha1, that enables heatmap support. There's an issue with nginx which is necessary to review