### PR TITLE
Set as default solr url engine

### DIFF
--- a/hypermap/settings.py
+++ b/hypermap/settings.py
@@ -276,7 +276,7 @@ MAPPROXY_CONFIG = os.path.join(MEDIA_ROOT, 'mapproxy_config')
 # solr+http://127.0.0.1:8983/solr/search
 # elasticsearch+http://localhost:9200/
 # elasticsearch+https://user:pass/domain:port/
-REGISTRY_SEARCH_URL = os.getenv('REGISTRY_SEARCH_URL', 'solr+http://127.0.0.1:8983/solr/search')
+REGISTRY_SEARCH_URL = os.getenv('REGISTRY_SEARCH_URL', 'elasticsearch+http://elasticsearch:9200/')
 REGISTRY_SEARCH_BATCH_SIZE = int(os.getenv('REGISTRY_SEARCH_BATCH_SIZE', 50))
 SEARCH_TYPE = REGISTRY_SEARCH_URL.split('+')[0]
 SEARCH_URL = REGISTRY_SEARCH_URL.split('+')[1]

--- a/hypermap/settings.py
+++ b/hypermap/settings.py
@@ -276,7 +276,7 @@ MAPPROXY_CONFIG = os.path.join(MEDIA_ROOT, 'mapproxy_config')
 # solr+http://127.0.0.1:8983/solr/search
 # elasticsearch+http://localhost:9200/
 # elasticsearch+https://user:pass/domain:port/
-REGISTRY_SEARCH_URL = os.getenv('REGISTRY_SEARCH_URL', None)
+REGISTRY_SEARCH_URL = os.getenv('REGISTRY_SEARCH_URL', 'solr+http://127.0.0.1:8983/solr/search')
 REGISTRY_SEARCH_BATCH_SIZE = int(os.getenv('REGISTRY_SEARCH_BATCH_SIZE', 50))
 SEARCH_TYPE = REGISTRY_SEARCH_URL.split('+')[0]
 SEARCH_URL = REGISTRY_SEARCH_URL.split('+')[1]


### PR DESCRIPTION
@ingenieroariel  @capooti 

What I did is set as default Solr url. It allows me to do `docker-compose build django` 

As you can see below: 

```
rancher@rancher:~/code/HHypermap$ docker-compose build django
Building django
Step 1 : FROM geonode/django:pycsw21
# Executing 4 build triggers...
Step 1 : COPY requirements.txt /usr/src/app/
 ---> Using cache
Step 1 : RUN pip install --no-cache-dir -r requirements.txt
 ---> Using cache
Step 1 : COPY . /usr/src/app/
Step 1 : RUN pip install --no-deps --no-cache-dir -e /usr/src/app/
 ---> Running in f06be6311873
You are using pip version 6.1.1, however version 9.0.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
Obtaining file:///usr/src/app
Installing collected packages: hhypermap
  Running setup.py develop for hhypermap
Successfully installed hhypermap
 ---> 7c918f0e5a80
Removing intermediate container c376407e6689
Removing intermediate container f06be6311873
Step 2 : MAINTAINER Ariel Núñez<ariel@terranodo.io>
 ---> Running in e754dd383ddd
 ---> f19dcb7142e1
Removing intermediate container e754dd383ddd
Successfully built f19dcb7142e1
```

Do you agree with that?