### PR TITLE
make 'view on site' link in layer and service admin page work

### DIFF
--- a/hypermap/aggregator/admin.py
+++ b/hypermap/aggregator/admin.py
@@ -2,6 +2,8 @@ from django.contrib import admin
 
 from django_celery_results.models import TaskResult
 
+from django.core.urlresolvers import reverse
+
 from models import (Service, Layer, Check, SpatialReferenceSystem, EndpointList,
                     Endpoint, LayerDate, LayerWM, Catalog, IssueType, Issue)
 
@@ -12,6 +14,9 @@ class ServiceAdmin(admin.ModelAdmin):
     list_display_links = ('id', )
     search_fields = ['title', 'url', ]
     list_filter = ('type', )
+
+    def view_on_site(self, obj):
+        return reverse("service_detail", args=[obj.catalog.slug, obj.uuid])
 
 
 class SpatialReferenceSystemAdmin(admin.ModelAdmin):
@@ -33,6 +38,9 @@ class LayerAdmin(admin.ModelAdmin):
     list_display = ('name', 'is_valid',  'title', 'service', )
     search_fields = ['name', 'title', ]
     list_filter = ('is_public', )
+
+    def view_on_site(self, obj):
+        return reverse("layer_detail", args=[obj.catalog.slug, obj.uuid])
 
 
 class LayerWMAdmin(admin.ModelAdmin):


### PR DESCRIPTION
use ModelAdmin.view_on_site(obj) instead of Model.get_absolute_url().
https://code.djangoproject.com/ticket/27757